### PR TITLE
Add modern portfolio page

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -1,0 +1,114 @@
+:root {
+  --bg: #ffffff;
+  --text: #1a1a1a;
+  --accent: #ff6600;
+}
+body.dark {
+  --bg: #1a1a1a;
+  --text: #f5f5f5;
+}
+body {
+  font-family: 'Poppins', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  margin: 0;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+.site-header {
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.logo {
+  font-weight: 600;
+  font-size: 1.25rem;
+  text-decoration: none;
+  color: var(--text);
+}
+.nav-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.5rem;
+  display: none;
+}
+.site-nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+.site-nav a {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 500;
+}
+.mode-toggle {
+  margin-left: 1rem;
+  cursor: pointer;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+}
+@media (max-width: 768px) {
+  .nav-toggle { display: block; }
+  .site-nav {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: var(--bg);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+  }
+  .site-nav.open { max-height: 300px; }
+  .site-nav ul { flex-direction: column; padding: 1rem; }
+}
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px,1fr));
+  gap: 1rem;
+  max-width: 1200px;
+  margin: 80px auto 2rem;
+  padding: 0 1rem;
+}
+.gallery-item {
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+  display: block;
+}
+.gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+  display: block;
+}
+.gallery-item .title {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.4);
+  color: #fff;
+  font-size: 1.25rem;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+.gallery-item:hover img { transform: scale(1.1); }
+.gallery-item:hover .title { opacity: 1; }
+.fade-in { opacity: 0; transform: translateY(20px); animation: fadeUp 0.6s forwards; }
+@keyframes fadeUp { to { opacity: 1; transform: translateY(0);} }

--- a/portfolio.html
+++ b/portfolio.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Portfolio - ASF Visuals LLC</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="portfolio.css">
+</head>
+<body>
+  <header class="site-header">
+    <a href="index.html" class="logo">ASF Visuals LLC</a>
+    <button id="navToggle" class="nav-toggle" aria-label="Toggle navigation">☰</button>
+    <nav id="navLinks" class="site-nav">
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="portfolio.html">Portfolio</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="contact.html">Contact</a></li>
+      </ul>
+    </nav>
+    <button id="modeToggle" class="mode-toggle">🌙</button>
+  </header>
+
+  <main class="gallery-grid">
+    <a class="gallery-item" href="gallery.html?filter=Animals">
+      <img src="images/gallery/WatermarkedImages/Animals/HHI25-01.jpg" alt="Animals">
+      <span class="title">Animals</span>
+    </a>
+    <a class="gallery-item" href="gallery.html?filter=Flowers">
+      <img src="images/gallery/WatermarkedImages/Flowers/Amaryllis.jpg" alt="Flowers">
+      <span class="title">Flowers</span>
+    </a>
+    <a class="gallery-item" href="gallery.html?filter=Hilton%20Head">
+      <img src="images/gallery/WatermarkedImages/Hilton Head/HHI25-03.jpg" alt="Hilton Head">
+      <span class="title">Hilton Head</span>
+    </a>
+    <a class="gallery-item" href="gallery.html?filter=People">
+      <img src="images/gallery/WatermarkedImages/People/AndrewGrad-01.jpg" alt="People">
+      <span class="title">People</span>
+    </a>
+    <a class="gallery-item" href="gallery.html?filter=Pittsburgh">
+      <img src="images/gallery/WatermarkedImages/Pittsburgh/DowntownSide-1.jpg" alt="Pittsburgh">
+      <span class="title">Pittsburgh</span>
+    </a>
+    <a class="gallery-item" href="gallery.html?filter=London">
+      <img src="images/gallery/WatermarkedImages/London/LondonEye.jpg" alt="London">
+      <span class="title">London</span>
+    </a>
+  </main>
+
+<script src="portfolio.js"></script>
+</body>
+</html>

--- a/portfolio.js
+++ b/portfolio.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const navToggle = document.getElementById('navToggle');
+  const navLinks = document.getElementById('navLinks');
+  const modeToggle = document.getElementById('modeToggle');
+  const body = document.body;
+
+  if (navToggle) {
+    navToggle.addEventListener('click', () => {
+      navLinks.classList.toggle('open');
+    });
+  }
+
+  if (localStorage.getItem('theme') === 'dark') {
+    body.classList.add('dark');
+  }
+
+  modeToggle.addEventListener('click', () => {
+    body.classList.toggle('dark');
+    localStorage.setItem('theme', body.classList.contains('dark') ? 'dark' : 'light');
+  });
+
+  document.querySelectorAll('.gallery-item').forEach((el, i) => {
+    el.style.animationDelay = `${i * 100}ms`;
+    el.classList.add('fade-in');
+  });
+});


### PR DESCRIPTION
## Summary
- create new `portfolio.html` with gallery blocks similar to Pixieset
- add styles for responsive masonry-like grid in `portfolio.css`
- add `portfolio.js` to handle menu, dark mode toggle and animations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cf6ed0310832cbe22270f7bd29331