### PR TITLE
Add real estate services page

### DIFF
--- a/real-estate.html
+++ b/real-estate.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="icon" href="images/OFLogo.png" type="image/png">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="ASF Visuals offers professional real estate photography and aerial services to showcase properties at their best.">
+  <meta name="keywords" content="real estate photography, property photos, drone real estate">
+  <link rel="canonical" href="https://www.asfvisuals412.com/real-estate.html">
+  <title>Real Estate Photography - ASF Visuals</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-XXXXXXX');
+  </script>
+  <script defer src="scroll.min.js"></script>
+</head>
+<body>
+  <header class="site-header">
+    <a href="index.html" class="logo-link">
+      <img src="images/TransparentLogo.png" alt="ASF Visuals Logo" loading="lazy">
+    </a>
+    <button
+      id="menu-toggle"
+      aria-controls="navbar"
+      aria-expanded="false"
+      aria-label="Toggle navigation"
+    >
+      <span class="bar"></span>
+      <span class="bar"></span>
+      <span class="bar"></span>
+    </button>
+    <nav id="navbar" class="site-nav">
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="gallery.html">Portfolio</a></li>
+        <li><a href="vlog.html">Vlog</a></li>
+        <li><a href="services.html">Services</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="contact.html">Contact</a></li>
+      </ul>
+    </nav>
+    <div class="cta-buttons">
+      <a href="vlog.html" class="btn">Watch Our Vlog</a>
+      <a href="contact.html" class="btn">Contact Us</a>
+    </div>
+  </header>
+
+  <main id="main">
+    <section id="real-estate" class="fade-up">
+      <div class="container">
+        <h2>Real Estate Photography Services</h2>
+        <p>Showcase your property with crisp, compelling visuals. Our real estate packages include interior and exterior coverage along with optional aerial perspectives.</p>
+        <ul>
+          <li>High-resolution interior and exterior photography</li>
+          <li>Drone imagery for aerial views</li>
+          <li>24–48 hour turnaround on edited photos</li>
+        </ul>
+        <div class="portfolio-grid">
+          <img src="images/DJI_0441.JPG" alt="Sample property exterior" loading="lazy">
+          <img src="images/DJI_0454.JPG" alt="Sample property interior" loading="lazy">
+        </div>
+        <p><a href="contact.html" class="btn">Request a Quote</a></p>
+      </div>
+    </section>
+  </main>
+
+  <a href="contact.html" class="book-btn">Book a Shoot</a>
+  <footer class="site-footer">
+    <form class="subscribe-form" aria-label="Newsletter signup" action="https://formspree.io/f/xovvrygq" method="POST">
+      <label for="footer-email" class="visually-hidden">Email</label>
+      <input id="footer-email" type="email" placeholder="you@example.com" required>
+      <button type="submit">Subscribe</button>
+    </form>
+    <div class="footer-cta">
+      <a href="vlog.html" class="btn">Watch Our Vlog</a>
+      <a href="contact.html" class="btn">Contact Us</a>
+    </div>
+    <p>&copy; 2025 ASF Visuals LLC. All rights reserved.</p>
+    <div class="social-links">
+      <a
+        href="https://www.linkedin.com/company/asf-visuals-llc/"
+        target="_blank"
+        rel="noopener"
+        aria-label="LinkedIn"
+      >
+        <img src="images/linkedin-icon.png" alt="LinkedIn" loading="lazy">
+      </a>
+      <a
+        href="https://www.instagram.com/asfvisuals/"
+        target="_blank"
+        rel="noopener"
+        aria-label="Instagram"
+      >
+        <img src="images/instagram-icon.png" alt="Instagram" loading="lazy">
+      </a>
+    </div>
+  </footer>
+
+  <script defer src="menuToggle.js"></script>
+  <script defer src="imageEnlarge.min.js"></script>
+</body>
+</html>

--- a/services.html
+++ b/services.html
@@ -166,6 +166,19 @@
             <tr>
               <td colspan="3" style="text-align: right;"><a href="gallery.html?filter=drone" class="view-work-link">View Our Work &raquo;</a></td>
             </tr>
+            <!-- Real Estate Photography -->
+            <tr>
+              <td rowspan="2" data-label="Service">Real Estate Photography</td>
+              <td data-label="Package">Standard Listing Photos (interior &amp; exterior)</td>
+              <td data-label="Price Range">Contact for Details</td>
+            </tr>
+            <tr>
+              <td data-label="Package">Premium Package (includes aerial drone imagery)</td>
+              <td data-label="Price Range">Contact for Details</td>
+            </tr>
+            <tr>
+              <td colspan="3" style="text-align: right;"><a href="real-estate.html" class="view-work-link">Learn More &raquo;</a></td>
+            </tr>
             <!-- Street & Urban Lifestyle Photography -->
             <tr>
               <td rowspan="2" data-label="Service">Street &amp; Urban Lifestyle Photography</td>


### PR DESCRIPTION
## Summary
- add dedicated page for real estate photography services with sample images and contact link
- extend services table with real estate packages and link to new page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b5b7a43c832c8ab4440ba6aaae2e