### PR TITLE
Add real estate services stylesheet

### DIFF
--- a/src/css/real-estate-services.css
+++ b/src/css/real-estate-services.css
@@ -1,0 +1,140 @@
+/*
+  Real Estate Services Stylesheet
+  Generated for ASF Visuals LLC
+*/
+
+:root {
+  --primary: #004e89;
+  --light: #f5f5f5;
+  --accent: #ffd700;
+  --dark: #333;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--light);
+  color: var(--dark);
+  line-height: 1.6;
+}
+
+/* Hero Section */
+.hero {
+  position: relative;
+  background: url('../../images/real-estate-hero.jpg') center/cover no-repeat;
+  padding: 6rem 1rem;
+  text-align: center;
+  color: #fff;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+}
+
+.hero h1 {
+  position: relative;
+  margin: 0;
+  font-size: 2rem;
+}
+
+/* Property Grid */
+.properties {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  padding: 2rem 1rem;
+}
+
+@media (min-width: 768px) {
+  .properties {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* Property Card */
+.property-card {
+  background: #fff;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.property-card:hover {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 6px 12px rgba(0,0,0,0.15);
+}
+
+.property-image {
+  position: relative;
+  padding-bottom: 56%;
+  overflow: hidden;
+}
+
+.property-image img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.price-badge {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  background: var(--accent);
+  color: #000;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-weight: 600;
+}
+
+.property-content {
+  padding: 1rem;
+}
+
+.property-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  color: var(--primary);
+}
+
+.property-desc {
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+}
+
+.cta-button {
+  display: inline-block;
+  background: var(--primary);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  text-decoration: none;
+  transition: background 0.3s ease;
+}
+
+.cta-button:hover {
+  background: #00345f;
+}
+
+/* Utilities */
+.transition {
+  transition: all 0.3s ease;
+}
+
+.mt-1 { margin-top: 0.5rem; }
+.mt-2 { margin-top: 1rem; }
+.mb-1 { margin-bottom: 0.5rem; }
+.mb-2 { margin-bottom: 1rem; }
+.p-1  { padding: 0.5rem; }
+.p-2  { padding: 1rem; }
+


### PR DESCRIPTION
## Summary
- add standalone CSS for real estate services page

## Testing
- `openai api completions.create --model code-davinci-002 --prompt "/* Create a full CSS stylesheet for a real estate services page on ASF Visuals LLC.   The page should include:   - A responsive hero section with background image and centered headline   - A mobile-first property grid (3 columns on desktop, stacking on mobile)   - Property card styles: image container, title, description, price badge, and a CTA button   - Hover effects (shadow lift, slight scale) on the cards   - CSS variables for a modern palette (e.g., --primary: #004e89; --light: #f5f5f5; --accent: #ffd700;)   - Typography using a sans-serif system font stack   - Smooth transitions and utility classes for spacing */" --max-tokens 800 --temperature 0` (connection error)
- `npm test` (package.json not found)


------
https://chatgpt.com/codex/tasks/task_e_6893c271ee5c832cba7860e603cbc2c4